### PR TITLE
Changed syntax and rewrote parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 stackc
+test
 x
 x.c
 x.py
 x.stc
+t.stc

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ FYI: Words are hashed by their first character, so that searches are a bit more 
 
 ### Comments
 
-Comments are declared by `--`, every character after `--` is ignored by the interpreter.
+Comments are declared by `//`, every character after `//` is ignored by the interpreter.
 
 ```
--- This is a comment.
--- Anything after `--` is ignored.
--- . . . . .
--- Does not cause stack underflow because it is not ran!
-65 emit -- prints an `A` character
+// This is a comment.
+// Anything after `//` is ignored.
+// . . . . .
+// Does not cause stack underflow because it is not ran!
+65 emit // prints an `A` character
 ```
 
 ```python
@@ -89,11 +89,11 @@ The follow operations pop 2 elements off the stack and push the result back on i
 | `%` | remainder of the two elements |
 
 ```
-1 2 + .  -- prints 3
-9 3 - .  -- prints 6
-5 6 * .  -- prints 30
-50 7 / . -- prints 7
-50 7 % . -- prints 1
+1 2 + .  // prints 3
+9 3 - .  // prints 6
+5 6 * .  // prints 30
+50 7 / . // prints 7
+50 7 % . // prints 1
 ```
 
 ```python
@@ -118,13 +118,13 @@ The following operations pop 2 elements off the stack and push 0 (if false) and 
 | `<` | lesser than |
 
 ```
-1 1 = .    -- prints 1 (true)
-0 1 = .    -- prints 0 (false)
-19 19 >= . -- prints 1 (true)
-20 19 >= . -- prints 1 (true)
-19 5 <= .  -- prints 0 (false)
-2 1 > .    -- prints 1 (true)
-5 5 < .    -- prints 0 (false)
+1 1 = .    // prints 1 (true)
+0 1 = .    // prints 0 (false)
+19 19 >= . // prints 1 (true)
+20 19 >= . // prints 1 (true)
+19 5 <= .  // prints 0 (false)
+2 1 > .    // prints 1 (true)
+5 5 < .    // prints 0 (false)
 ```
 
 ```python
@@ -149,12 +149,12 @@ The following words will print into standard output. Will have an error if the o
 
 ```
 65 1 2 3
-.s   -- prints 4
-.    -- prints 3
-.    -- prints 2
-.    -- prints 1
-emit -- prints `A`
-.s   -- prints 0
+.s   // prints 4
+.    // prints 3
+.    // prints 2
+.    // prints 1
+emit // prints `A`
+.s   // prints 0
 ```
 
 ```python
@@ -213,7 +213,7 @@ This is    tabbed!ABC
 | `drop` | pops the first element |
 | `swap` | swaps the first two elements |
 | `over` | duplicates the second element and pushes it to the top |
-| `rot` | rotates the first 3 elements, `1 2 3 rot . . .` -- prints `1 3 2` |
+| `rot` | rotates the first 3 elements, `1 2 3 rot` -> `2 3 1` |
 
 ### Control Flow
 
@@ -226,16 +226,16 @@ If you want to simulate a regular `else`, as in other languages, just use a `els
 Nested if/else are also supported!
 
 ```
-if 0 then          -- evaluates to false
+if 0 then          // evaluates to false
   12 .
-elseif 1 then      -- evaluates to true
-  if 2 1 - then    -- evaluates to 1 which is true
-    23 .           -- 23 is printed
-  elseif 1 then    -- skipped to jump ahead to the `end` block
+elseif 1 then      // evaluates to true
+  if 2 1 - then    // evaluates to 1 which is true
+    23 .           // 23 is printed
+  elseif 1 then    // skipped to jump ahead to the `end` block
     34 .
   end
 elseif 1 then
-  45 .             -- never evaluated as it is equivalent to placing 2 `else` after one another.
+  45 .             // never evaluated as it is equivalent to placing 2 `else` after one another.
 end
 ```
 
@@ -296,7 +296,7 @@ It is possible to define custom words, which is useful for repeated operations. 
 
 Do note that recursion is not supported. Weird things may happen.
 
-`def <wordname> <word body> enddef`
+`def <wordname> <word body> end`
 
 After the definition of the custom word, every other occurrence of a word is effectively replaced by the word body.
 
@@ -305,13 +305,13 @@ Ideally, one adds in a "function signature" as a comment to denote how many elem
 The following program computes the nth fibonaci number (this is what I came up with but there might be a better way). It is kinda tricky to have to juggle with 3 values in the stack.
 
 ```
--- duplicates top 2 elements
-def dup2 -- A, B -> A, B, A, B
+// duplicates top 2 elements
+def dup2 // A, B -> A, B, A, B
   over over
-enddef
+end
 
--- nth fibonacci number
-def fib -- int -> int
+// nth fibonacci number
+def fib // int -> int
   1 -
   0 1 rot
   while dup 0 > then
@@ -320,9 +320,9 @@ def fib -- int -> int
     rot 1 -
   end
   drop drop
-enddef
+end
 
-29 fib .                -- prints 317811
+29 fib .                // prints 317811
 ```
 
 is equivalent to
@@ -363,10 +363,12 @@ Some tests are available in `tests` folder, each `.stc` file is matched with a `
 
 ## TODO
 
-- re-write parsing for if-elseif-end while-end def-end
+- re-write parsing for if-elseif-end while-end def-end (some form of jump point system, instead of computing end multiple times)
 - simple type system (int, char, string, everything on the stack has a type)
 - every object is type-value-...-values
 - 'A' to register a character
+- use stderr instead of stdout when logging errors
+- re-write `test.py` testing framework in C
 
 - break statement to jump to the end
 - import/include files so we can actually import and use the stdlib.stc!!!
@@ -375,12 +377,16 @@ Some tests are available in `tests` folder, each `.stc` file is matched with a `
 - Bitwise operations
 - Rule 110 program
 - read input?
+- floats?
 
 - have access to a second stack?
 - string manipulation words
 
+- array
+
 - meta-evaluator (stackc being able to evaluate stackc)
-- compile stackc file into executable
+- compile stackc programs into assembly -> executables
+- re-write StackC compiler in StackC
 
 stdlib:
 - print in stdlib instead (its there but I'll remove it from primitive after include)

--- a/stdlib.stc
+++ b/stdlib.stc
@@ -1,23 +1,26 @@
--- The standard library for StackC
+// The standard library for StackC
 
-def dup2 -- A, B -> A, B, A, B
+def false 0 enddef
+def true 1 enddef
+
+def dup2 // A, B -> A, B, A, B
   over over
 enddef
 
-def rot3 -- A, B, C -> C, A, B
+def rot3 // A, B, C -> C, A, B
   rot rot
 enddef
 
-def cr -- None -> None
+def cr // None -> None
   "\n" print
 enddef
 
--- peek operation
-def , -- int -> int
+// peek operation
+def , // int -> int
   dup .
 enddef
 
--- haven't removed as a primitive
+// haven't removed as a primitive
 def print2
   while dup 0 > then
     1 -
@@ -26,17 +29,17 @@ def print2
   drop drop
 enddef
 
-def reverseN -- n ints, n -> n ints
+def reverseN // n ints, n -> n ints
   "not possible without an additional stack?" print
 enddef
 
--- MATH OPERATIONS (math library) --
+// MATH OPERATIONS (math library) //
 
-def neg -- a -> -a
+def neg // a -> -a
   0 swap -
 enddef
 
-def sumN -- n ints, n -> int
+def sumN // n ints, n -> int
   0
   while swap dup 0 > then
     1 -
@@ -45,9 +48,8 @@ def sumN -- n ints, n -> int
   drop
 enddef
 
-def factorial -- n -> n!
-  1
-  swap
+def factorial // n -> n!
+  1 swap
   while dup 0 > then
     dup rot *
     swap 1 -
@@ -55,7 +57,7 @@ def factorial -- n -> n!
   drop
 enddef
 
-def pow -- a, b -> a^b
+def pow // a, b -> a^b
   swap dup
   while rot dup 1 > then
     1 -
@@ -65,13 +67,13 @@ def pow -- a, b -> a^b
   drop swap drop
 enddef
 
-def abs -- a -> |a|
+def abs // a -> |a|
   if dup 0 < then
     neg
   end
 enddef
 
-def max -- a, b -> max(a, b)
+def max // a, b -> max(a, b)
   if dup2 > then
     drop
   elseif 1 then
@@ -79,7 +81,7 @@ def max -- a, b -> max(a, b)
   end
 enddef
 
-def min -- a, b -> max(a, b)
+def min // a, b -> max(a, b)
   if dup2 < then
     drop
   elseif 1 then
@@ -87,8 +89,8 @@ def min -- a, b -> max(a, b)
   end
 enddef
 
--- using Euclidean algorithm (supports negative numbers)
-def gcd
+// using Euclidean algorithm (supports negative numbers)
+def gcd // a, b -> gcd(a, b)
   while dup then
     swap over %
   end
@@ -96,8 +98,8 @@ def gcd
 enddef
 
 
--- TESTS --
--- temporary because no include yet
+// -- TESTS -- //
+// temporary because no include yet
 
 if 14 5 pow 537824 = then
   "14^5 Correct\n" print
@@ -154,5 +156,5 @@ end
 1 2 min . cr
 2 1 min . cr
 
-1071 462 gcd . cr -- 21
--531 789 gcd . cr -- 3
+1071 462 gcd . cr // 21
+-531 789 gcd . cr // 3

--- a/tests/defword.stc
+++ b/tests/defword.stc
@@ -7,11 +7,9 @@ end
 
 // nth fibonacci number
 def fib // int -> int
-  "Fib\n" print
   1 -
   0 1 rot
   while dup 0 > then
-    "While\n" print
     rot rot
     dup2 + rot drop
     rot 1 -
@@ -19,8 +17,8 @@ def fib // int -> int
   drop drop
 end
 
-// 10 fib .
-// 29 fib .
+10 fib .
+29 fib .
 
 def sum3 + + end
 1 2 3 sum3 .

--- a/tests/defword.stc
+++ b/tests/defword.stc
@@ -1,28 +1,30 @@
--- duplicates top 2 elements
-def dup2 -- int, int -> int, int, int, int
+// duplicates top 2 elements
+def dup2 // int, int -> int, int, int, int
   over over
-enddef
+end
 
 2 3 dup2 . . . .
 
--- nth fibonacci number
-def fib -- int -> int
+// nth fibonacci number
+def fib // int -> int
+  "Fib\n" print
   1 -
   0 1 rot
   while dup 0 > then
+    "While\n" print
     rot rot
     dup2 + rot drop
     rot 1 -
   end
   drop drop
-enddef
+end
 
-10 fib .
-29 fib .
+// 10 fib .
+// 29 fib .
 
-def sum3 + + enddef
+def sum3 + + end
 1 2 3 sum3 .
 3 3 3 sum3 .
 
-def ++ 1 + enddef
+def ++ 1 + end
 65 ++ .

--- a/tests/emit.stc
+++ b/tests/emit.stc
@@ -1,3 +1,3 @@
 33 101 114 101 104 116 32 105 72
 emit emit emit emit emit emit emit emit emit
--- Hi there!
+// Hi there!

--- a/tests/if.o
+++ b/tests/if.o
@@ -1,1 +1,3 @@
-+++0 is less than 510 is more than 523++
++++0 is less than 5
+10 is more than 5
+23++

--- a/tests/if.stc
+++ b/tests/if.stc
@@ -1,4 +1,4 @@
--- 43 is +, 45 is -
+// 43 is +, 45 is -
 
 if 0 then
   45 emit
@@ -36,27 +36,27 @@ elseif 1 then
   . " is less than 5" print
 end
 
--- nested loops
+// nested loops
 
-if 0 then          -- evaluates to false
+if 0 then          // evaluates to false
   12 .
-elseif 1 then      -- evaluates to true
-  if 2 1 - then    -- evaluates to 1 which is true
-    23 .           -- 23 is printed
-  elseif 1 then    -- skipped to jump ahead to the `end` block
+elseif 1 then      // evaluates to true
+  if 2 1 - then    // evaluates to 1 which is true
+    23 .           // 23 is printed
+  elseif 1 then    // skipped to jump ahead to the `end` block
     34 .
   end
 elseif 1 then
-  45 .             -- never evaluated as it is equivalent to placing 2 `else` after one another.
+  45 .             // never evaluated as it is equivalent to placing 2 `else` after one another.
 end
 
 if 1 then
   if 1 then
     if 1 then
-      43 emit      -- printed
+      43 emit      // printed
     end
   elseif 1 then
     45 emit
   end
-  43 emit          -- printed
+  43 emit          // printed
 end

--- a/tests/if.stc
+++ b/tests/if.stc
@@ -24,16 +24,16 @@ end
 
 0
 if dup 5 > then
-  . " is more than 5" print
+  . " is more than 5\n" print
 elseif 1 then
-  . " is less than 5" print
+  . " is less than 5\n" print
 end
 
 10
 if dup 5 > then
-  . " is more than 5" print
+  . " is more than 5\n" print
 elseif 1 then
-  . " is less than 5" print
+  . " is less than 5\n" print
 end
 
 // nested loops

--- a/tests/strings.o
+++ b/tests/strings.o
@@ -2,5 +2,5 @@ Hello World
 This is	 tabbed!ABCABC
 
 	\
--- comment in a string
+// comment in a string
 "Quotes are great", bob's single quotes are also supported!

--- a/tests/strings.stc
+++ b/tests/strings.stc
@@ -4,12 +4,12 @@
 
 "C" "B" "A" print print print
 
--- "FA"A print -- is invalid
+// "FA"A print -- is invalid
 
 "ABC" print
 
 "\n\n\t\\\n" print
 
-"-- comment in a string\n" print
+"// comment in a string\n" print
 
 "\"Quotes are great\", bob\'s single quotes are also supported!\r\n" print

--- a/tests/while.stc
+++ b/tests/while.stc
@@ -1,7 +1,7 @@
-def , dup . enddef
+def , dup . end
 
--- FizzBuzz from 1 to 100
-def FIZZ_MAX 100 enddef -- using as a constant
+// FizzBuzz from 1 to 100
+def FIZZ_MAX 100 end // using as a constant
 1
 while dup FIZZ_MAX <= then
   if dup 15 % 0 = then
@@ -17,7 +17,7 @@ while dup FIZZ_MAX <= then
 end
 drop
 
--- Simple 10 to 1 loop
+// Simple 10 to 1 loop
 
 10
 while dup 0 > then
@@ -26,7 +26,7 @@ while dup 0 > then
 end
 drop
 
--- Nested while loops
+// Nested while loops
 
 5
 while dup 0 > then
@@ -40,7 +40,7 @@ while dup 0 > then
 end
 drop
 
--- "Hi" 5 times
+// "Hi" 5 times
 
 5
 while dup 0 > then


### PR DESCRIPTION
Comments are now marked by `//` instead of `--`.
Example: `// this is a comment` instead of `-- this was the old comment style`.

Definition endings are now marked by `end` instead of `enddef`.
Example: `def x 3 end` instead of `def x 3 enddef`

`def` must be on the highest level. `while` and `if` should now be able to be nested properly.

Valid code:
```stc
if
  while 0 then end
  1
then
  "Hi\n" print
end
```

Invalid code:
```stc
if 1 then
  def nonesteddef end
end
```